### PR TITLE
Changed certificate secret name

### DIFF
--- a/EndpointLambdas/GettingCertTest/Function.cs
+++ b/EndpointLambdas/GettingCertTest/Function.cs
@@ -17,7 +17,7 @@ namespace GettingCertTest;
 public class Function
 {
 
-    private static readonly string secretName = "Certificate_PFX";
+    private static readonly string secretName = "Certificate";
     private readonly IAmazonSecretsManager secretsManagerClient;
     private readonly AmazonDynamoDBClient client;
 


### PR DESCRIPTION
- Was originally 'Certificate_PFX'
- Now is 'Certificate'
- Had to create a new pfx file for our updated mTLS